### PR TITLE
Add support for gnome shell 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/codilia/upower-battery",
   "uuid": "upower-battery@codilia.com",


### PR DESCRIPTION
Tested on Gnome 49 (available in Fedora 43 beta). Working great !