### PR TITLE
add gnome 50 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/codilia/upower-battery",
   "uuid": "upower-battery@codilia.com",


### PR DESCRIPTION
Tested on Fedora 44 with Gnome 50, working as expected.